### PR TITLE
Add bounce email parsers for Python and PHP storing to PostgreSQL

### DIFF
--- a/parse_bounce_email.php
+++ b/parse_bounce_email.php
@@ -1,0 +1,71 @@
+<?php
+// Parse bounce e-mail and optionally store details into PostgreSQL
+// Usage: php parse_bounce_email.php FILE [DSN]
+
+if ($argc < 2) {
+    fwrite(STDERR, "Usage: php parse_bounce_email.php FILE [DSN]\n");
+    exit(1);
+}
+
+$file = $argv[1];
+$dsn  = $argv[2] ?? null;
+$raw  = file_get_contents($file);
+
+// Split headers and body
+list($headerText, $body) = preg_split("/\r?\n\r?\n/", $raw, 2);
+$headers = [];
+$current = null;
+foreach (preg_split("/\r?\n/", $headerText) as $line) {
+    if ($line === '') {
+        continue;
+    }
+    if (preg_match('/^\s+/', $line) && $current !== null) {
+        // Continuation line
+        $headers[$current] .= ' ' . trim($line);
+    } else {
+        $parts = explode(':', $line, 2);
+        if (count($parts) === 2) {
+            $current = trim($parts[0]);
+            $headers[$current] = trim($parts[1]);
+        }
+    }
+}
+
+$subject = $headers['Subject'] ?? '';
+
+$errorCode = null;
+if (preg_match('/Status:\s*([245]\.[0-9]\.[0-9])/', $raw, $m)) {
+    $errorCode = $m[1];
+} elseif (preg_match('/Diagnostic-Code:\s*[^;]+;\s*([0-9]{3}\s[0-9.]+)/', $raw, $m)) {
+    $errorCode = $m[1];
+}
+
+$info = [
+    'subject' => $subject,
+    'headers' => $headers,
+    'body' => $body,
+    'error_code' => $errorCode,
+];
+
+if ($dsn) {
+    $pdo = new PDO($dsn);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $pdo->exec('CREATE TABLE IF NOT EXISTS bounces (
+        id SERIAL PRIMARY KEY,
+        subject TEXT,
+        headers JSON,
+        body TEXT,
+        error_code TEXT
+    )');
+    $stmt = $pdo->prepare('INSERT INTO bounces (subject, headers, body, error_code) VALUES (:subject, :headers, :body, :error_code)');
+    $stmt->execute([
+        ':subject' => $info['subject'],
+        ':headers' => json_encode($info['headers']),
+        ':body' => $info['body'],
+        ':error_code' => $info['error_code']
+    ]);
+    echo "Stored bounce information in PostgreSQL.\n";
+} else {
+    echo json_encode($info, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) . PHP_EOL;
+}
+

--- a/parse_bounce_email.py
+++ b/parse_bounce_email.py
@@ -1,0 +1,93 @@
+import argparse
+import json
+import os
+import re
+from email import policy
+from email.parser import BytesParser
+from typing import Dict, Optional
+
+def parse_bounce(raw_bytes: bytes) -> Dict[str, Optional[str]]:
+    """Parse a raw bounce e-mail and return relevant information."""
+    msg = BytesParser(policy=policy.default).parsebytes(raw_bytes)
+    headers = dict(msg.items())
+    subject = msg.get('subject', '')
+
+    # Extract plain text body
+    if msg.is_multipart():
+        parts = [part.get_payload(decode=True) or b'' for part in msg.walk()
+                 if part.get_content_type() == 'text/plain']
+        body = b"\n".join(parts).decode(errors='ignore')
+    else:
+        body = msg.get_payload(decode=True).decode(errors='ignore')
+
+    # Look for standard DSN fields
+    error_code = None
+    patterns = [
+        re.compile(r"Status:\s*([245]\.[0-9]\.[0-9])"),
+        re.compile(r"Diagnostic-Code:\s*[^;]+;\s*([0-9]{3}\s[0-9.]+)")
+    ]
+    for pat in patterns:
+        match = pat.search(raw_bytes.decode(errors='ignore'))
+        if match:
+            error_code = match.group(1)
+            break
+
+    return {
+        'subject': subject,
+        'headers': headers,
+        'body': body,
+        'error_code': error_code,
+    }
+
+
+def store_in_postgres(dsn: str, info: Dict[str, Optional[str]]) -> None:
+    """Store parsed bounce information into PostgreSQL."""
+    import psycopg2  # Lazy import so script works without dependency when not storing
+
+    conn = psycopg2.connect(dsn)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS bounces (
+            id SERIAL PRIMARY KEY,
+            subject TEXT,
+            headers JSONB,
+            body TEXT,
+            error_code TEXT
+        )
+        """
+    )
+    cur.execute(
+        "INSERT INTO bounces (subject, headers, body, error_code) VALUES (%s, %s, %s, %s)",
+        (
+            info['subject'],
+            json.dumps(info['headers']),
+            info['body'],
+            info['error_code'],
+        ),
+    )
+    conn.commit()
+    cur.close()
+    conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Parse bounce e-mail and store in PostgreSQL')
+    parser.add_argument('file', help='Path to bounce e-mail file')
+    parser.add_argument('--dsn', help='PostgreSQL DSN e.g. "dbname=test user=postgres"')
+    args = parser.parse_args()
+
+    with open(args.file, 'rb') as f:
+        raw = f.read()
+
+    info = parse_bounce(raw)
+
+    if args.dsn:
+        store_in_postgres(args.dsn, info)
+        print('Stored bounce information in PostgreSQL.')
+    else:
+        print(json.dumps(info, indent=2, ensure_ascii=False))
+
+
+if __name__ == '__main__':
+    main()

--- a/sample_bounce.eml
+++ b/sample_bounce.eml
@@ -1,0 +1,29 @@
+From: MAILER-DAEMON@example.com
+To: sender@example.com
+Subject: Undelivered Mail Returned to Sender
+Date: Mon, 1 Jan 2024 00:00:00 +0000
+Content-Type: multipart/report; report-type=delivery-status;
+ boundary="XXXX"
+
+--XXXX
+Content-Type: text/plain; charset=UTF-8
+
+This is the mail system at host example.com.
+
+I'm sorry to have to inform you that your message could not
+be delivered to one or more recipients. It's attached below.
+
+--XXXX
+Content-Type: message/delivery-status
+
+Final-Recipient: rfc822; invalid@example.com
+Action: failed
+Status: 5.1.1
+Diagnostic-Code: smtp; 550 5.1.1 <invalid@example.com>: Recipient address rejected: User unknown
+
+--XXXX
+Content-Type: message/rfc822
+
+[original message]
+
+--XXXX--


### PR DESCRIPTION
## Summary
- Parse raw bounce emails to extract headers, subject, body, and error codes
- Store parsed bounce information in a PostgreSQL `bounces` table
- Provide both Python and PHP scripts for parsing

## Testing
- `pytest`
- `python parse_bounce_email.py sample_bounce.eml`
- `php parse_bounce_email.php sample_bounce.eml`


------
https://chatgpt.com/codex/tasks/task_e_6899cdb669648328b57526974a5db0fd